### PR TITLE
FixEditTagViewOnNarrowDisplayDevise

### DIFF
--- a/app/assets/stylesheets/modules/_folder_index.scss
+++ b/app/assets/stylesheets/modules/_folder_index.scss
@@ -57,21 +57,21 @@
           }
         }
         &__tag {
-          padding-left: 3%;
+          padding-left: 20px;
           display: flex;
           justify-content: space-between;
           &__list {
-            width: 90%;
-            height: 25px;
+            width: 220px;
+            height: 30px;
             border-radius: 10px;
-            margin: 5px 5px 5px 5px;
+            margin: 10px 10px 10px 10px;
             padding: 0 0 0 10px;
             background-color: white;
             text-align: center;
-            line-height: 25px;
+            line-height: 30px;
             display: flex;
             color: darkblue;
-            font-size: 18px;
+            font-size: 20px;
             &__icon {
               font-size: 18px;
             }


### PR DESCRIPTION
# what
Fixed tag length on edit tag view when it was accessed by a narrow display devise. 
# why
Because it was too long.